### PR TITLE
Align Python version across docs and workflow

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- align GitHub Actions crawler with README by using Python 3.11

## Testing
- `python -m compileall -q crawler`

------
https://chatgpt.com/codex/tasks/task_b_686b7d669c50832fb5511c604a284b17