### PR TITLE
Hardcode HF dataset repo name

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Upload data to Hugging Face
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          HF_DATASET_REPO: ${{ secrets.HF_DATASET_REPO }}
+          HF_DATASET_REPO: vGassen/Dutch-Open-Data-Tuchtrecht-Disciplinary-Court-Cases
         run: |
           pip install huggingface_hub git-lfs
           git lfs install

--- a/README.md
+++ b/README.md
@@ -52,18 +52,18 @@ Or add to cron to automate daily.
 
 ## Hugging Face
 
-Set the following environment variables before running the fetch script:
+Set the following environment variable before running the fetch script:
 
 * `HF_TOKEN` – an access token with write permissions
-* `HF_DATASET_REPO` – Hugging Face dataset repository name
 * `HF_PRIVATE` – set to `true` to create a private dataset (optional)
 
-The dataset will be created under `HF_DATASET_REPO`, for example
-`vGassen/Dutch-Open-Data-Tuchtrecht-Disciplinary-Court-Cases`.
+The dataset is uploaded to
+`vGassen/Dutch-Open-Data-Tuchtrecht-Disciplinary-Court-Cases` as configured in
+the GitHub Actions workflow.
 
 ## GitHub Actions
 
 A workflow is included to automate fetching. It runs every Sunday and can also
-be triggered manually from the Actions tab. Configure the `HF_TOKEN` and
-`HF_DATASET_REPO` secrets in your repository settings so the workflow can push
-the latest JSONL shards to your Hugging Face dataset.
+be triggered manually from the Actions tab. Configure the `HF_TOKEN` secret in
+your repository settings so the workflow can push the latest JSONL shards to the
+configured Hugging Face dataset.


### PR DESCRIPTION
## Summary
- fix workflow to set HF_DATASET_REPO directly
- update README to explain that the dataset repo name is configured in the workflow

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686cc0f3d608832fac88c68f6b352367